### PR TITLE
Added section ID as a query param for playlist uploads

### DIFF
--- a/models/operations/uploadplaylist.go
+++ b/models/operations/uploadplaylist.go
@@ -53,6 +53,8 @@ type UploadPlaylistRequest struct {
 	// If the `force` argument is set to 0, a new playlist will be created suffixed with the date and time that the duplicate was uploaded.
 	//
 	Force Force `queryParam:"style=form,explode=true,name=force"`
+
+	SectionID int `queryParam:"style=form,explode=true,name=sectionID"`
 }
 
 func (o *UploadPlaylistRequest) GetPath() string {

--- a/playlists.go
+++ b/playlists.go
@@ -942,6 +942,7 @@ func (s *Playlists) UploadPlaylist(ctx context.Context, path string, force opera
 	request := operations.UploadPlaylistRequest{
 		Path:  path,
 		Force: force,
+		SectionID: 1,
 	}
 
 	baseURL := utils.ReplaceParameters(s.sdkConfiguration.GetServerDetails())


### PR DESCRIPTION
The UploadPlaylist function does not work in the existing library. When testing this with an API client it seems that a sectionID query parameter is required. I'm not entirely sure what it does, but having it present and setting it to 1 fixes the issue. This PR simply updates the UploadPlaylistRequest model to support the new query param. It also updates the UploadPlaylist function to always include it and sets it to 1.