### PR TITLE
Change success status code from 200 to 201 for CreateOAuthPin

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -1934,7 +1934,7 @@ func (s *Authentication) CreateOAuthPin(ctx context.Context, request operations.
 	}
 
 	switch {
-	case httpRes.StatusCode == 200:
+	case httpRes.StatusCode == 201:
 		switch {
 		case utils.MatchContentType(httpRes.Header.Get("Content-Type"), `application/json`):
 			rawBody, err := utils.ConsumeRawBody(httpRes)


### PR DESCRIPTION
The success code for the CreateOauthPin endpoint is a 201, not a 200.

This isn't in the Plex docs and for some reason the whole authentication stuff is missed from their OpenAPI spec files

Fixes #8 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OAuth PIN creation to correctly recognize successful responses, improving authentication flow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->